### PR TITLE
adding initial editor support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,12 +134,13 @@ pub fn add_todo(title: Option<String>) {
     std::process::Command::new(get_editor()).arg(fp).status().expect("TODO: editing todoeditmsg file failed");
     let mut buf = String::new();
     std::fs::File::open(fp).expect("TODO: opening todoeditmsg for reading failed").read_to_string(&mut buf).expect("TODO: reading final todoeditmsg file failed");
+    std::fs::remove_file(fp).expect("todoeditmsg couldn't be removed once it was read");
     // TODO: maybe rename notes to body?
     let mut not_comments = buf.lines().filter(|e| !e.trim_start().starts_with("#"));
     let final_title = not_comments.next().expect("Couldn't find title of new TODO");
     let notes: Vec<&str> = not_comments.collect();
     let full_notes = notes.join("\n");
-    println!("read in {buf}");
+
     
     let connection = &mut establish_connection();
     // TODO: add id support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod models;
 pub mod schema;
 
+use std::io::{Read, Write};
+
 use self::schema::todos;
 
 use chrono::Utc;
@@ -13,6 +15,7 @@ use models::{NewTodo, Todos};
 
 const BIN: &str = env!("CARGO_PKG_NAME");
 const BIN_VERSION: &str = env!("CARGO_PKG_VERSION");
+const DEFAULT_EDITOR: &str = "vi";
 
 #[derive(Parser)]
 #[command(
@@ -47,7 +50,7 @@ enum Commands {
     AddTodo {
         /// title of the new TODO
         #[clap()]
-        title: String,
+        title: Option<String>,
     },
     /// list current TODOs
     ListTodos,
@@ -61,16 +64,36 @@ fn print_version() {
     println!("{} {}", BIN, get_version_str());
 }
 
+// TODO: make this return a Path
+fn get_project_data_folder() -> std::path::PathBuf{
+    let mut data_folder = data_dir().expect("Couldn't get data dir");
+    data_folder.push(BIN);
+    if ! data_folder.exists() {
+        std::fs::create_dir(data_folder.as_path()).expect("Wasn't able to create the folder {data_folder}");
+    }
+    return data_folder;
+}
+
 fn get_db_file() -> std::path::PathBuf{
-    let mut db_file = data_dir().expect("Couldn't get data dir");
-    db_file.push("events.sqlite3");
+    let mut db_file = get_project_data_folder();
+    db_file.push("todos.sqlite3");
     return db_file
 }
 
-fn get_todo_file() -> std::path::PathBuf{
-    let mut todo_file = data_dir().expect("Couldn't get data dir");
-    todo_file.push("TODO");
+fn get_todoeditmsg_file() -> std::path::PathBuf{
+    let mut todo_file = get_project_data_folder();
+    // TODO: we should clean this up if it's left beind at startup
+    todo_file.push("TODO_EDITMSG");
+    
     return todo_file
+}
+
+fn get_editor() -> String {
+    let editor = std::env::var("EDITOR");
+    match editor {
+        Ok(editor) => editor,
+        Err(_) => DEFAULT_EDITOR.to_string(),
+    }
 }
 
 fn print_db_file() {
@@ -83,13 +106,44 @@ pub fn establish_connection() -> SqliteConnection {
         .unwrap_or_else(|_| panic!("Error connecting to {}", database_url));
     pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
     //TODO: a match here could perform log a message for successful migrations
-    conn.run_pending_migrations(MIGRATIONS).unwrap();
+    conn.run_pending_migrations(MIGRATIONS).expect("Migrations couldn't be run");
     return conn;
 }
 
-pub fn add_todo(title: String) {
+pub fn add_todo(title: Option<String>) {
+    // TODO: There should be a way to supply body easily just like in `git commit -m ""`, but
+    //  don't forget multiline messages with multiple -m's
+    let title_str = match title {
+        Some(t) => t,
+        None => "<title>".to_string(),
+    };
+    let p_buff = get_todoeditmsg_file();
+    let fp = p_buff.as_path();
+    let mut file = std::fs::File::create(fp).expect("File {fp} couldn't be created");
+    file.write_fmt(
+        format_args!(
+            "{}
+
+# This is a comment, lines starting with a # will be ignored
+
+# The first non-comment line will assumed to be the title and every other line will be saved as notes
+",
+            title_str,
+         )
+    ).expect("TODO: Writing initial todoeditmsg file failed");
+    std::process::Command::new(get_editor()).arg(fp).status().expect("TODO: editing todoeditmsg file failed");
+    let mut buf = String::new();
+    std::fs::File::open(fp).expect("TODO: opening todoeditmsg for reading failed").read_to_string(&mut buf).expect("TODO: reading final todoeditmsg file failed");
+    // TODO: maybe rename notes to body?
+    let mut not_comments = buf.lines().filter(|e| !e.trim_start().starts_with("#"));
+    let final_title = not_comments.next().expect("Couldn't find title of new TODO");
+    let notes: Vec<&str> = not_comments.collect();
+    let full_notes = notes.join("\n");
+    println!("read in {buf}");
+    
     let connection = &mut establish_connection();
-    let new_todo = NewTodo{title: &title, notes: "", created_on: Utc::now()};
+    // TODO: add id support
+    let new_todo = NewTodo{title: final_title, notes: &full_notes.as_str(), created_on: Utc::now()};
     diesel::insert_into(todos::table)
         .values(&new_todo)
         .returning(Todos::as_returning())
@@ -124,7 +178,8 @@ pub fn run_cli() {
             print_db_file();
         }
         Some(Commands::AddTodo { title }) => {
-            add_todo(title.to_string());
+            // TODO: maybe don't clone here
+            add_todo(title.clone());
         }
         Some(Commands::ListTodos) => {
             list_todos();

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -31,7 +31,7 @@ fn test_locate_db() {
     .success()
     .stdout(
         predicate::str::ends_with(
-            "events.sqlite3\n",
+            "todos.sqlite3\n",
         )
     );
 }


### PR DESCRIPTION
In this PR I add support for popping open an editor when a new TODO is being added.

In the edited file comments are supported and the first line is assumed to be the title while the rest is the notes/body of that TODO