### PR TITLE
more user friendly CLI options and output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +585,12 @@ checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1287,6 +1303,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "colored",
  "diesel",
  "diesel_migrations",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 [dependencies]
 chrono = "0.4.38"
 clap = { version = "4.4.2", features = ["derive", "string"] }
+colored = "2.2.0"
 diesel = { version = "2.2.1", features = ["chrono", "sqlite", "returning_clauses_for_sqlite_3_35"] }
 diesel_migrations = "2.2.0"
 dirs = "5.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ enum Commands {
         title: Option<String>,
     },
     /// list current TODOs
+    #[clap(visible_alias = "ls")]
     List,
     Delete {
         #[clap()]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ enum Commands {
     /// list current TODOs
     #[clap(visible_alias = "ls")]
     List,
+    #[clap(visible_alias = "rm")]
     Delete {
         #[clap()]
         id: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,9 +206,7 @@ pub fn list_todos() {
         .load(connection)
         .expect("Error loading posts");
     for post in results {
-        println!("id: {}", encode_id(post.id.try_into().unwrap()));
-        println!("title: {}", post.title);
-        println!("notes: {}", post.notes);
+        println!("{} {}", encode_id(post.id.try_into().unwrap()), post.title);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use self::schema::todos;
 
 use chrono::Utc;
 use clap::{Parser, Subcommand};
+use colored::Colorize;
 use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
@@ -65,6 +66,7 @@ enum Commands {
 fn get_squids() -> Sqids {
     Sqids::builder()
         .min_length(5)
+        .alphabet("abcdefghijklmnopqrstuvwxyz1234567890".chars().collect())
         .build()
         .expect("Couldn't get squids")
 }
@@ -207,7 +209,11 @@ pub fn list_todos() {
         .load(connection)
         .expect("Error loading posts");
     for post in results {
-        println!("{} {}", encode_id(post.id.try_into().unwrap()), post.title);
+        println!(
+            "{} {}",
+            encode_id(post.id.try_into().unwrap()).yellow(),
+            post.title
+        );
     }
 }
 


### PR DESCRIPTION
In this PR I add:
* `rm` alias for `delete`
* `ls` alias for `list`
* better list output with color
* modifying alphabet for ids to be more human friendly