### PR TITLE
Better list flags

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,7 +39,14 @@ enum Commands {
     #[clap(visible_alias = "ls")]
     List {
         #[arg(long, action = clap::builder::ArgAction::SetTrue)]
-        show_completed: bool,
+        /// shows both completed and open TODOs, overwrites other flags
+        all: bool,
+        #[arg(long, action = clap::builder::ArgAction::SetTrue)]
+        /// shows only completed TODOs
+        completed: bool,
+        #[arg(long, action = clap::builder::ArgAction::SetTrue)]
+        /// shows only open TODOs
+        open: bool,
     },
     #[clap(visible_alias = "rm")]
     Delete {
@@ -90,8 +97,12 @@ pub fn run_cli() {
             // TODO: maybe don't clone here
             crate::add_todo(title.clone());
         }
-        Some(Commands::List { show_completed }) => {
-            crate::list_todos(if *show_completed { Some(true) } else { None });
+        Some(Commands::List { all, completed , open}) => {
+            if *all {
+                crate::list_todos(Some(true), Some(true));
+            } else {
+                crate::list_todos(Some(*completed), Some(*open));
+            }
         }
         Some(Commands::Delete { id }) => {
             crate::delete_todo(id.to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,14 +232,21 @@ pub fn edit_todo(show_id: String) {
     println!("TODO updated successfully")
 }
 
-pub fn list_todos(show_completed: Option<bool>) {
+pub fn list_todos(
+    show_completed: Option<bool>,
+    show_open: Option<bool>,
+) {
     let s_completed = show_completed.unwrap_or(false);
+    let s_open = show_open.unwrap_or(false);
     use self::schema::todos::dsl::*;
     use diesel::sqlite::Sqlite;
     let connection = &mut establish_connection();
     let mut query = todos.select(Todos::as_select()).into_boxed::<Sqlite>();
-    if !s_completed {
+    if !s_completed && s_open {
         query = query.filter(completed.is_null());
+    } else if !s_open && s_completed {
+        query = query.filter(completed.is_not_null());
+        
     }
     let results = query
         .order_by(id.desc())

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -254,7 +254,7 @@ fn test_list_todos() {
     add_todo(Some("Third TODO".to_string()));
 
     // List TODOs
-    list_todos(None);
+    list_todos(None, None);
 
     cleanup_test_env();
 }


### PR DESCRIPTION
This PR extends the list flags like so:
```
❯ cargo run -- ls --help
list current TODOs

Usage: workingon list [OPTIONS]

Options:
      --all        shows both completed and open TODOs, overwrites other flags
      --completed  shows only completed TODOs
      --open       shows only open TODOs
  -h, --help       Print help
```