### PR TITLE
Adding reopen command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -115,6 +115,9 @@ pub fn run_cli() {
         Some(Commands::Complete { id }) => {
             crate::complete_todo(id.to_string());
         }
+        Some(Commands::Reopen { id }) => {
+            crate::reopen_todo(id.to_string());
+        }
         None => {}
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,18 @@ pub fn complete_todo(show_id: String) {
     println!("TODO was completed")
 }
 
+pub fn reopen_todo(show_id: String) {
+    use self::schema::todos::dsl::*;
+    use chrono::DateTime;
+    let connection = &mut establish_connection();
+    let decoded_id = decode_id(&show_id);
+    diesel::update(todos.find(decoded_id))
+        .set(completed.eq(None::<DateTime<Utc>>))
+        .execute(connection)
+        .expect("TODO couldn't be reopened");
+    println!("TODO was reopened")
+}
+
 pub fn edit_todo(show_id: String) {
     use self::schema::todos::dsl::*;
     let connection = &mut establish_connection();


### PR DESCRIPTION
Adding new command:
```
❯ cargo run -- reopen -h
reopen a TODO

Usage: workingon reopen <ID>

Arguments:
  <ID>  

Options:
  -h, --help  Print help
```