### PR TITLE
chore: release 1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "workingon"
-version = "1.3.0"
+version = "1.4.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workingon"
-version = "1.3.0"
+version = "1.4.1"
 description = "CLI to track what you're working on"
 authors = ["Mark Keller"]
 edition = "2021"


### PR DESCRIPTION
Forgot to bump the version string, so this version is literally just a string update